### PR TITLE
Added temporary color scheme and font-family

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,12 @@
+:root {
+    /* color scheme variables */
+}
+
+h1 {
+    font-family: "Cinzel Decorative";
+    font-weight: bold;
+}
+
+p {
+    font-family: "Open Sans", sans-serif;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,5 +1,8 @@
 :root {
     /* color scheme variables */
+    --primary-color: rgb(83, 13, 36);
+    --secondary-color: rgb(199, 78, 48);
+    --tertiary-color: white;
 }
 
 h1 {

--- a/index.html
+++ b/index.html
@@ -6,11 +6,13 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- links to font-family -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Open+Sans&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.3/dist/css/uikit.min.css" />
-    <link rel="stylesheet" href="assets\style.css">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Open+Sans&display=swap" rel="stylesheet">
+        <!-- link to UIKit -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.3/dist/css/uikit.min.css" />
+        <link rel="stylesheet" href="assets\style.css">
     </head>
     <body>
         

--- a/index.html
+++ b/index.html
@@ -6,8 +6,11 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.3/dist/css/uikit.min.css" />
-        <link rel="stylesheet" href="assets\style.css">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Open+Sans&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.3/dist/css/uikit.min.css" />
+    <link rel="stylesheet" href="assets\style.css">
     </head>
     <body>
         


### PR DESCRIPTION
**Please do not delete this branch until the color scheme and font-family have been finalized!**

## Completed
- Temporary color scheme in `:root` of `styles.css`:
    - Primary: `rgb(83, 13, 36)`
    - Secondary: `rgb(199, 78, 48)`
    - Tertiary: `white`
- Temporary font-family from Google Fonts:
    - Headers: Cinzel Decorative
    - `<p>`: Open Sans

**These are all just placeholders for now, so please let me know if you have other suggestions!**